### PR TITLE
chore: release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2](https://github.com/rcorre/pbls/compare/v1.2.1...v1.2.2) - 2026-05-29
+
+### Fixed
+
+- Add context to errors and format using alt
+
 ## [1.2.1](https://github.com/rcorre/pbls/compare/v1.2.0...v1.2.1) - 2026-05-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pbls"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbls"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 license = "MIT"
 description = "Protobuf Language Server"


### PR DESCRIPTION



## 🤖 New release

* `pbls`: 1.2.1 -> 1.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.2](https://github.com/rcorre/pbls/compare/v1.2.1...v1.2.2) - 2026-05-29

### Fixed

- Add context to errors and format using alt
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).